### PR TITLE
Add str method to event types

### DIFF
--- a/django_event_sourcing/models.py
+++ b/django_event_sourcing/models.py
@@ -18,6 +18,9 @@ class EventType(str, enum.Enum):
     def __hash__(self):
         return hash(self.fully_qualified_value)
 
+    def __str__(self):
+        return self.fully_qualified_value
+
 
 class EventTypeField(models.CharField):
     """Stores the fully qualified value of an event type."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,6 +27,9 @@ class TestEventType:
 
         assert hash(DumberEventType.TEST) != hash(DummyEventType.TEST)
 
+    def test_stringify(self, admin_user):
+        assert str(DummyEventType.TEST) == "dummy.test"
+
 
 class TestEventTypeField:
     def test_from_db_value(self):


### PR DESCRIPTION
EventTypes need to be stringified with their fully qualified value, so 
easy debugging and serialization